### PR TITLE
log warning if messages received while chat is closed

### DIFF
--- a/bedrock/entity/get_history.py
+++ b/bedrock/entity/get_history.py
@@ -22,8 +22,9 @@ async def main():
     # Queries the workflow for the conversation summary
     summary = await handle.query(EntityBedrockWorkflow.get_summary_from_history)
 
-    print("Conversation Summary:")
-    print(summary)
+    if summary is not None:
+        print("Conversation Summary:")
+        print(summary)
 
 
 if __name__ == "__main__":

--- a/bedrock/entity/workflows.py
+++ b/bedrock/entity/workflows.py
@@ -122,6 +122,11 @@ class EntityBedrockWorkflow:
 
     @workflow.signal
     async def user_prompt(self, prompt: str) -> None:
+        # Chat ended but the workflow is waiting for a chat summary to be generated
+        if self.chat_ended:
+            workflow.logger.warn(f"Message dropped due to chat closed: {prompt}")
+            return
+
         self.prompt_queue.append(prompt)
 
     @workflow.signal

--- a/bedrock/signals_and_queries/get_history.py
+++ b/bedrock/signals_and_queries/get_history.py
@@ -18,6 +18,13 @@ async def main():
     print(
         *(f"{speaker.title()}: {message}\n" for speaker, message in history), sep="\n"
     )
+    
+    # Queries the workflow for the conversation summary
+    summary = await handle.query(SignalQueryBedrockWorkflow.get_summary_from_history)
+
+    if summary is not None:
+        print("Conversation Summary:")
+        print(summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added code to warn that a new chat message will be dropped if the chat has closed and a summary is being generated.

Changed history getting script to not print a conversation summary if one doesn't exist yet.